### PR TITLE
Add phpcbf support

### DIFF
--- a/php-beautifier.el
+++ b/php-beautifier.el
@@ -142,10 +142,13 @@ Call the beautifier backend on INPUT-BUFFER between START-POINT and END-POINT
 points and place the result into OUTPUT-BUFFER.
 
 Returns `t` if the process executed correctly or `NIL` if it failed."
-  (zerop (shell-command-on-region
-          start-point end-point
-          (php-beautifier--create-shell-command)
-          input-buffer t output-buffer t)))
+  (let ((result (shell-command-on-region
+                 start-point end-point
+                 (php-beautifier--create-shell-command)
+                 input-buffer t output-buffer t)))
+    (if (php-beautifier-phpcbf-can-use-p)
+        (= 1 result)
+        (zerop result))))
 
 (defun php-beautifier--format-region (start end)
   "Replace a region from START to END with content formatted by PHP_Beautifier.

--- a/php-beautifier.el
+++ b/php-beautifier.el
@@ -63,6 +63,46 @@
   :options '("tabs" "spaces")
   :type '(string))
 
+(defcustom php-beautifier-phpcbf-path "phpcbf"
+  "The full path to the `phpcbf` executable."
+  :group 'php-beautifier
+  :type '(file))
+
+(defcustom php-beautifier-phpcbf-standard nil
+  "The coding standard to use when calling phpcbf."
+  :group 'php-beautifier
+  :type '(string))
+
+
+;; PHPCBF standards helpers
+
+(defun php-beautifier-phpcbf-valid-standard-p (standard-name)
+  "Check STANDARD-NAME is registered with phpcbf."
+  (member standard-name (php-beautifier-phpcbf-standards)))
+
+(defun php-beautifier-phpcbf-standards ()
+  "Fetch a list of all standards registered with phpcbf."
+  (php-beautifier--phpcbf-parse-standards (php-beautifier--phpcbf-fetch-standards)))
+
+(defun php-beautifier--phpcbf-fetch-standards ()
+  "Call the phpcbf executable and return the standards it lists."
+  (shell-command-to-string
+   (format "%s -i" php-beautifier-phpcbf-path)))
+
+(defun php-beautifier--phpcbf-parse-standards (standards)
+  "Parse a list of STANDARDS and return as a list of names."
+  ;; TODO: Remove the magic number `35` here - it's the length of:
+  ;; "The installed coding standards are MySource, PEAR and PHPCS\n"
+  ;; which isn't useful for none-English installs.
+  ;; Should probably remove the `and` as well.
+  (mapcar 'php-beautifier--trim-standard-name
+          (delete "and" (split-string (substring standards 35)))))
+
+(defun php-beautifier--trim-standard-name (standard)
+  "Trim trailing spaces and commas from STANDARD name."
+  (if (string-match "[\ ,]*$" standard)
+      (replace-match "" nil nil standard)
+      standard))
 
 ;; Code formatting functions
 

--- a/php-beautifier.el
+++ b/php-beautifier.el
@@ -78,7 +78,8 @@
 
 (defun php-beautifier-phpcbf-valid-standard-p (standard-name)
   "Check STANDARD-NAME is registered with phpcbf."
-  (member standard-name (php-beautifier-phpcbf-standards)))
+  (when (> (length standard-name) 0)
+    (member standard-name (php-beautifier-phpcbf-standards))))
 
 (defun php-beautifier-phpcbf-standards ()
   "Fetch a list of all standards registered with phpcbf."

--- a/php-beautifier.el
+++ b/php-beautifier.el
@@ -74,6 +74,23 @@
   :type '(string))
 
 
+;; PHPCBF integration
+
+(defun php-beautifier-phpcbf-installed-p ()
+  "Check if phpcbf is installed and configured correctly."
+  (executable-find php-beautifier-phpcbf-path))
+
+(defun php-beautifier-phpcbf-can-use-p ()
+  "Check if phpcbf is installed and a valid standard is set."
+  (and (php-beautifier-phpcbf-installed-p)
+       (php-beautifier-phpcbf-valid-standard-p php-beautifier-phpcbf-standard)))
+
+(defun php-beautifier--create-phpcbf-shell-command ()
+  "Create the shell command to call phpcbf."
+  (format "%s --standard=%s"
+          php-beautifier-phpcbf-path
+          php-beautifier-phpcbf-standard))
+
 ;; PHPCBF standards helpers
 
 (defun php-beautifier-phpcbf-valid-standard-p (standard-name)
@@ -109,11 +126,14 @@
 
 (defun php-beautifier--create-shell-command ()
   "Create the shell command to call PHP_Beautifier."
-  (format "%s %s"
+  (format "%s %s%s"
           php-beautifier-executable-path
           (if (string= "spaces" php-beautifier-indent-method)
               "--indent_spaces"
-              "--indent_tabs")))
+              "--indent_tabs")
+          (if (php-beautifier-phpcbf-can-use-p)
+              (format " | %s" (php-beautifier--create-phpcbf-shell-command))
+              "")))
 
 (defun php-beautifier--exec (input-buffer start-point end-point output-buffer)
   "Execute the beautifier on a region.

--- a/test/php-beautifier-test.el
+++ b/test/php-beautifier-test.el
@@ -42,6 +42,13 @@
    (stub php-beautifier--phpcbf-fetch-standards => "The installed coding standards are MySource, PEAR and PHPCS\n")
    (should-not (php-beautifier-phpcbf-valid-standard-p "SomeOtherStandard"))))
 
+(ert-deftest php-beautifier-test/valid-standard-returns-nil-when-empty-or-nil ()
+  (with-mock
+   (stub php-beautifier--phpcbf-fetch-standards => (error "Should not reach this far"))
+   (should-not (php-beautifier-phpcbf-valid-standard-p nil))
+   (should-not (php-beautifier-phpcbf-valid-standard-p ""))))
+
+
 ;; Indentation method parameter checks
 
 (ert-deftest php-beautifier-test/adds-space-indent-method-correctly ()

--- a/test/php-beautifier-test.el
+++ b/test/php-beautifier-test.el
@@ -18,6 +18,30 @@
    (php-beautifier-format-buffer)))
 
 
+;; phpcbf standard checks
+
+(ert-deftest php-beautifier-test/can-fetch-all-phpcbf-standards ()
+  (with-mock
+   (stub php-beautifier--phpcbf-fetch-standards => "The installed coding standards are MySource, PEAR and PHPCS\n")
+   (let ((result (php-beautifier-phpcbf-standards)))
+     (should (listp result)))))
+
+(ert-deftest php-beautifier-test/can-parse-valid-phpcbf-standards-list ()
+  (let ((standards "The installed coding standards are MySource, PEAR and PHPCS\n"))
+    (should (listp (php-beautifier--phpcbf-parse-standards standards)))))
+
+(ert-deftest php-beautifier-test/valid-standard-returns-t-when-valid ()
+  (with-mock
+   (stub php-beautifier--phpcbf-fetch-standards => "The installed coding standards are MySource, PEAR and PHPCS\n")
+   (should (php-beautifier-phpcbf-valid-standard-p "MySource"))
+   (should (php-beautifier-phpcbf-valid-standard-p "PEAR"))
+   (should (php-beautifier-phpcbf-valid-standard-p "PHPCS"))))
+
+(ert-deftest php-beautifier-test/valid-standard-returns-nil-when-invalid ()
+  (with-mock
+   (stub php-beautifier--phpcbf-fetch-standards => "The installed coding standards are MySource, PEAR and PHPCS\n")
+   (should-not (php-beautifier-phpcbf-valid-standard-p "SomeOtherStandard"))))
+
 ;; Indentation method parameter checks
 
 (ert-deftest php-beautifier-test/adds-space-indent-method-correctly ()

--- a/test/php-beautifier-test.el
+++ b/test/php-beautifier-test.el
@@ -17,6 +17,30 @@
    (mock (shell-command-on-region 1 11 * * t * t) => 0)
    (php-beautifier-format-buffer)))
 
+(ert-deftest php-beautifier-tests/exec-checks-for-0-result-when-no-phpcbf ()
+  ;; CBF not used but 1 returned - should return nil
+  (with-mock
+   (mock (shell-command-on-region 1 1 * * t * t) => 1)
+   (stub php-beautifier-phpcbf-can-use-p => nil)
+   (should-not (php-beautifier--exec nil 1 1 nil)))
+  ;; CBF not used and 0 returned - should return true
+  (with-mock
+   (mock (shell-command-on-region 1 1 * * t * t) => 0)
+   (stub php-beautifier-phpcbf-can-use-p => nil)
+   (should (php-beautifier--exec nil 1 1 nil))))
+
+(ert-deftest php-beautifier-tests/exec-checks-for-1-result-when-using-phpcbf ()
+  ;; CBF used but 0 returned - should return nil
+  (with-mock
+   (mock (shell-command-on-region 1 1 * * t * t) => 0)
+   (stub php-beautifier-phpcbf-can-use-p => t)
+   (should-not (php-beautifier--exec nil 1 1 nil)))
+  ;; CBF used and 1 returned - should return true
+  (with-mock
+   (mock (shell-command-on-region 1 1 * * t * t) => 1)
+   (stub php-beautifier-phpcbf-can-use-p => t)
+   (should (php-beautifier--exec nil 1 1 nil))))
+
 
 ;; phpcbf integration
 

--- a/test/php-beautifier-test.el
+++ b/test/php-beautifier-test.el
@@ -18,6 +18,53 @@
    (php-beautifier-format-buffer)))
 
 
+;; phpcbf integration
+
+(ert-deftest php-beautifier-test/phpcbf-installed-p-returns-t-when-installed ()
+  (with-mock
+   (stub executable-find => "/path/to/phpcbf")
+   (should (php-beautifier-phpcbf-installed-p))))
+
+(ert-deftest php-beautifier-test/phpcbf-installed-p-returns-nil-when-not-installed ()
+  (with-mock
+   (stub executable-find => nil)
+   (should-not (php-beautifier-phpcbf-installed-p))))
+
+(ert-deftest php-beautifier-test/phpcbf-can-use-p-returns-t-when-installed-and-valid-standard ()
+  (with-mock
+   (stub executable-find => "/path/to/phpcbf")
+   (stub php-beautifier--phpcbf-fetch-standards => "The installed coding standards are MySource, PEAR and PHPCS\n")
+   (let ((php-beautifier-phpcbf-standard "MySource"))
+     (should (php-beautifier-phpcbf-can-use-p)))))
+
+(ert-deftest php-beautifier-test/phpcbf-can-use-p-returns-nil-when-no-phpcbf ()
+  (with-mock
+   (stub executable-find => nil)
+   (stub php-beautifier-phpcbf-valid-standard-p => t)
+   (should-not (php-beautifier-phpcbf-can-use-p))))
+
+(ert-deftest php-beautifier-test/phpcbf-can-use-p-returns-nil-when-no-valid-standard ()
+  (with-mock
+   (stub executable-find => "/path/to/phpcbf")
+   (stub php-beautifier-phpcbf-valid-standard-p => nil)
+   (should-not (php-beautifier-phpcbf-can-use-p))))
+
+(ert-deftest php-beautifier-test/can-creates-phpcbf-command-line ()
+  (let ((php-beautifier-phpcbf-path "/path/to/phpcbf")
+        (php-beautifier-phpcbf-standard "Testing"))
+    (should (string= "/path/to/phpcbf --standard=Testing"
+                     (php-beautifier--create-phpcbf-shell-command)))))
+
+(ert-deftest php-beautifier-test/adds-phpcbf-command-line-when-setup ()
+  (with-mock
+   (stub executable-find => "/path/to/phpcbf")
+   (stub php-beautifier-phpcbf-standards => (list "Testing"))
+   (let ((php-beautifier-executable-path "/path/to/php_beautifier")
+         (php-beautifier-phpcbf-path "/path/to/phpcbf")
+         (php-beautifier-phpcbf-standard "Testing"))
+     (should (string= "/path/to/php_beautifier --indent_spaces | /path/to/phpcbf --standard=Testing"
+                      (php-beautifier--create-shell-command))))))
+
 ;; phpcbf standard checks
 
 (ert-deftest php-beautifier-test/can-fetch-all-phpcbf-standards ()


### PR DESCRIPTION
This change adds `phpcbf` support to the beautification process. If `phpcbf` is installed and a standard is set, the result from `php_beautifier` will be run through `phpcbf` as well.

This fixes issue #1